### PR TITLE
Test windows build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,6 +37,8 @@ install:
   # Install CxxWrap
   - set BUILD_ON_WINDOWS=1 
   - C:\projects\julia-build\bin\julia -E "Pkg.add(\"CxxWrap\")"
+  # Run Julia Pkg build
+  - C:\projects\julia-build\bin\julia -E "Pkg.clone(pwd(), \"Xtensor\"); Pkg.build(\"Xtensor\"); Pkg.test(\"Xtensor\");"
   # Build pure Cpp tests
   - C:\projects\julia-build\bin\julia -E "Pkg.dir(\"CxxWrap\", \"deps\", \"usr\", \"lib\", \"cmake\")" > temp.txt
   - set /p CxxWrap_DIR=<temp.txt
@@ -44,9 +46,6 @@ install:
   - cd deps\xtensor-julia
   - cmake -G "NMake Makefiles" -D CxxWrap_DIR=%CxxWrap_DIR% -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -D BUILD_TESTS=ON -D Julia_EXECUTABLE=C:\projects\julia-build\bin\julia .
   - nmake test_xtensor_julia
-  # Run Julia Pkg build
-  #- cd ..\..
-  #- C:\projects\julia-build\bin\julia -E "Pkg.clone(pwd(), \"Xtensor\"); Pkg.build(\"Xtensor\"); Pkg.test(\"Xtensor\");"
 
 build_script:
   - C:\projects\julia-build\bin\julia -E "Pkg.dir(\"CxxWrap\", \"deps\", \"usr\", \"lib\")" > temp.txt

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,5 @@
 using BinDeps
+using CxxWrap
 
 @BinDeps.setup
 

--- a/deps/xtensor-julia-examples/CMakeLists.txt
+++ b/deps/xtensor-julia-examples/CMakeLists.txt
@@ -17,9 +17,12 @@ include_directories(${xtensor-julia_INCLUDE_DIR})
 add_library(tensors SHARED tensors.cpp)
 target_link_libraries(tensors CxxWrap::cxx_wrap)
 
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
 install(TARGETS
-  tensors 
-LIBRARY DESTINATION lib${LIBDIR_SUFFIX}
-ARCHIVE DESTINATION lib${LIBDIR_SUFFIX}
-RUNTIME DESTINATION lib${LIBDIR_SUFFIX}
-INCLUDES DESTINATION include)
+  tensors
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xtensor-julia-examples)


### PR DESCRIPTION
It seems that the example dll is generated properly on windows, however, 

```julia
@BinDeps.install Dict([
    (:tensors, :_l_tensors)
])
```

fails on windows.

cc @barche. By any chance, do you know what is going on here?