### PR TITLE
Add more julia tests

### DIFF
--- a/deps/xtensor-julia-examples/CMakeLists.txt
+++ b/deps/xtensor-julia-examples/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 list(APPEND CMAKE_CXX_FLAGS "-std=c++14 -march=native")
 add_definitions(-DJULIA_ENABLE_THREADING)
+add_definitions(-DNOMINMAX)
 
 find_package(CxxWrap REQUIRED)
 find_package(xtensor REQUIRED)

--- a/deps/xtensor-julia-examples/tensors.cpp
+++ b/deps/xtensor-julia-examples/tensors.cpp
@@ -1,18 +1,78 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
 #include <cxx_wrap.hpp>
 
+#include <numeric>
+
+#include "xtensor/xmath.hpp"
+#include "xtensor/xarray.hpp"
+
+#include "xtensor-julia/jlarray.hpp"
 #include "xtensor-julia/jltensor.hpp"
+#include "xtensor-julia/jlvectorize.hpp"
+
+// Examples
+
+double test_access(const xt::jltensor<double, 2> m)
+{
+    return m(1, 1);
+}
+
+double example1(xt::jlarray<double> m)
+{
+    return m(0);
+}
+
+xt::jlarray<double> example2(xt::jlarray<double> m)
+{
+    return m + 2;
+}
+
+// Readme Examples
+
+double readme_example1(xt::jlarray<double> m)
+{
+    auto sines = xt::sin(m);
+    return std::accumulate(sines.begin(), sines.end(), 0.0);
+}
+
+double readme_example2(double i, double j)
+{
+    return std::sin(i) -  std::cos(j);
+}
+
+// Vectorize Examples
+
+int add(int i, int j)
+{
+    return i + j;
+}
 
 namespace tensors
 {
-    double test_access(const xt::jltensor<double, 2> m)
-    {
-        return m(1, 1);
-    }
 
     void init_tensor_module(cxx_wrap::Module& mod)
     {
         // Test jltensor
         mod.method("test_access", test_access);
+        mod.method("example1", example1);
+
+        mod.method("example2", example2);
+
+        mod.method("readme_example1", readme_example1);
+        mod.method("readme_example2", xt::jlvectorize(readme_example2));
+
+        mod.method("vectorize_example1", xt::jlvectorize(add));
+
+        mod.method("compare_shapes", [](const xt::jlarray<double> a, const xt::jlarray<double> b) {
+            return a.shape() == b.shape();
+        });
     }
 }
 

--- a/deps/xtensor-julia/include/xtensor-julia/jlarray.hpp
+++ b/deps/xtensor-julia/include/xtensor-julia/jlarray.hpp
@@ -82,7 +82,7 @@ namespace xt
 
         explicit jlarray(const shape_type& shape);
         explicit jlarray(const shape_type& shape, const_reference value);
-        explicit jlarray(jl_array_t* jl);
+        jlarray(jl_array_t* jl);
 
         jlarray(const self_type&);
         self_type& operator=(const self_type&);
@@ -398,6 +398,19 @@ namespace cxx_wrap
         xt::jlarray<T> operator()(jl_array_t* arr) const
         {
             return xt::jlarray<T>(arr);
+        }
+    };
+
+    // Conversions
+    template<class T>
+    struct static_type_mapping<xt::jlarray<T>>
+    {
+        using type = jl_array_t*;
+        static constexpr bool is_dynamic = false;
+
+        static jl_datatype_t* julia_type()
+        {
+            return (jl_datatype_t*)apply_array_type(static_type_mapping<T>::julia_type(), 1);
         }
     };
 }

--- a/deps/xtensor-julia/include/xtensor-julia/jltensor.hpp
+++ b/deps/xtensor-julia/include/xtensor-julia/jltensor.hpp
@@ -77,7 +77,7 @@ namespace xt
 
         explicit jltensor(const shape_type& shape);
         explicit jltensor(const shape_type& shape, const_reference value);
-        explicit jltensor(jl_array_t* jl);
+        jltensor(jl_array_t* jl);
 
         jltensor(const self_type&);
         self_type& operator=(const self_type&);


### PR DESCRIPTION
This PR reproduces the tests that we have in `xtensor-python`. Current issues.

1) `CxxWrap`'s `add_lambda` function takes its third argument (the pointer to `operator()`)  `const`, which prevents the use of functors where `operator()` is not const qualified.

    _Question_: is there a deep reason for the third argument of `add_lambda` to be `const`? cc @barche 

2) Unlike numpy arrays, in Julia, N-D arrays with different numbers of dimensions have different types. So in order to return an array with a number of dimension determined at runtime (such as for numpy-style broadcasting), we must create the type at runtime, which is what we do in the specialization of `ConvertToJulia::operator()`.

    Now, when using `module.method` with a function, this uses `mapped_return_type` which relies on the typedefs of `mapped_return_type`. By chance, regardless of the dimension, this is always `jl_array_t*`.

   For this reason, even though we use dynamic type mapping, we *must* override `static_type_mapping` for the typedefs here.