### PR TITLE
Add complex test

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda install gtest cmake xtensor=0.10.2 -c conda-forge
+  - conda install gtest cmake xtensor=0.10.4 -c conda-forge
   # Install CxxWrap
   - set BUILD_ON_WINDOWS=1 
   - C:\projects\julia-build\bin\julia -E "Pkg.add(\"CxxWrap\")"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ install:
     - conda update -q conda
     - conda info -a
     # Install xtensor and other conda requirements
-    - conda install xtensor==0.10.2 -c conda-forge
+    - conda install xtensor==0.10.4 -c conda-forge
     - cd deps/xtensor-julia/test
     - conda env create -f ./test-environment.yml
     - source activate test-xtensor-julia

--- a/deps/xtensor-julia-examples/tensors.cpp
+++ b/deps/xtensor-julia-examples/tensors.cpp
@@ -70,6 +70,8 @@ namespace tensors
 
         mod.method("vectorize_example1", xt::jlvectorize(add));
 
+        mod.method("rect_to_polar", xt::jlvectorize([](const std::complex<double> x) { return std::abs(x); }));
+
         mod.method("compare_shapes", [](const xt::jlarray<double> a, const xt::jlarray<double> b) {
             return a.shape() == b.shape();
         });

--- a/deps/xtensor-julia/include/xtensor-julia/jlarray.hpp
+++ b/deps/xtensor-julia/include/xtensor-julia/jlarray.hpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <array>
 #include <algorithm>
+#include <complex>
 #include <exception>
 
 #include "xtensor/xbuffer_adaptor.hpp"
@@ -41,6 +42,19 @@ namespace xt
     struct xcontainer_inner_types<jlarray<T>>
     {
         using container_type = xbuffer_adaptor<jlcxx::mapped_julia_type<T>>;
+        using shape_type = std::vector<std::size_t>;
+        using strides_type = shape_type;
+        using backstrides_type = shape_type;
+        using inner_shape_type = xbuffer_adaptor<std::size_t>;
+        using inner_strides_type = strides_type;
+        using inner_backstrides_type = backstrides_type;
+        using temporary_type = jlarray<T>;
+    };
+
+    template <class T>
+    struct xcontainer_inner_types<jlarray<std::complex<T>>>
+    {
+        using container_type = xbuffer_adaptor<std::complex<T>>;
         using shape_type = std::vector<std::size_t>;
         using strides_type = shape_type;
         using backstrides_type = shape_type;

--- a/deps/xtensor-julia/include/xtensor-julia/jltensor.hpp
+++ b/deps/xtensor-julia/include/xtensor-julia/jltensor.hpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <array>
 #include <algorithm>
+#include <complex>
 #include <exception>
 
 #include "xtensor/xbuffer_adaptor.hpp"
@@ -41,6 +42,19 @@ namespace xt
     struct xcontainer_inner_types<jltensor<T, N>>
     {
         using container_type = xbuffer_adaptor<jlcxx::mapped_julia_type<T>>;
+        using shape_type = std::array<std::size_t, N>;
+        using strides_type = shape_type;
+        using backstrides_type = shape_type;
+        using inner_shape_type = shape_type;
+        using inner_strides_type = strides_type;
+        using inner_backstrides_type = backstrides_type;
+        using temporary_type = jltensor<T, N>;
+    };
+
+    template <class T, std::size_t N>
+    struct xcontainer_inner_types<jltensor<std::complex<T>, N>>
+    {
+        using container_type = xbuffer_adaptor<std::complex<T>>;
         using shape_type = std::array<std::size_t, N>;
         using strides_type = shape_type;
         using backstrides_type = shape_type;


### PR DESCRIPTION
As per https://github.com/JuliaInterop/CxxWrap.jl/pull/69, the `jlcxx::mapped_julia_type<std::complex<T>>` should be exactly `std::complex<T>`.  This is not the case in upstream CxxWrap because doing so creates a runtime issue on windows for an unknown reason.

For this reason, we specialize the inner types for `std::complex<T>` so that the correct type is used.