### PR TITLE
Update xtensor, fixup Julia HOME, drop Julia 0.5

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,9 +33,9 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda install gtest cmake xtensor==0.15.1 -c conda-forge
+  - conda install gtest cmake xtensor==0.15.4 -c conda-forge
   # Install CxxWrap
-  - set BUILD_ON_WINDOWS=1 
+  - set BUILD_ON_WINDOWS=1
   - C:\projects\julia-build\bin\julia -E "Pkg.add(\"CxxWrap\")"
   # Run Julia Pkg build
   - C:\projects\julia-build\bin\julia -E "Pkg.clone(pwd(), \"Xtensor\"); Pkg.build(\"Xtensor\"); Pkg.test(\"Xtensor\");"

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ install:
     - conda update -q conda
     - conda info -a
     # Install xtensor and other conda requirements
-    - conda install xtensor==0.15.1 cmake -c conda-forge
+    - conda install xtensor==0.15.4 cmake -c conda-forge
     - cd deps/xtensor-julia
     # Install CxxWrap
     - julia -E "Pkg.add(\"CxxWrap\")"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
           packages:
             - g++-4.9
       env: COMPILER=gcc GCC=4.9
-      julia: 0.5
+      julia: 0.6.0
     - os: linux
       addons:
         apt:
@@ -36,31 +36,26 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - g++-6
+      env: COMPILER=gcc GCC=6 JULIA=0.6.1
+      julia: 0.6.1
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
             - g++-5
       env: COMPILER=gcc GCC=5
       julia: nightly
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env: COMPILER=gcc GCC=5
-      julia: 0.5
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      env: COMPILER=gcc GCC=6
-      julia: 0.5
     - os: osx
       osx_image: xcode8
       compiler: clang
       julia: 0.5
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+      julia: 0.6.1
   allow_failures:
     - julia: nightly
 env:

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -46,7 +46,7 @@ end
 xtl_version = "0.4.0"
 
 # Version of xtensor-core to vendor
-xtensor_version = "0.15.1"
+xtensor_version = "0.15.4"
 
 xtl_steps = @build_steps begin
   `git clone -b $xtl_version --single-branch https://github.com/QuantStack/xtl $xtl_srcdir`
@@ -61,12 +61,12 @@ xtensor_core_steps = @build_steps begin
 end
 
 xtensor_julia_steps = @build_steps begin
-  `cmake -G "$genopt" -DCMAKE_PREFIX_PATH=$prefix -DCMAKE_INSTALL_PREFIX=$prefix -DJlCxx_DIR=$jlcxx_dir -Dxtensor_DIR=$xtensor_dir -DCMAKE_INSTALL_LIBDIR=lib $xtensor_julia_srcdir`
+  `cmake -G "$genopt" -DCMAKE_PREFIX_PATH=$prefix -DCMAKE_INSTALL_PREFIX=$prefix -DJlCxx_DIR=$jlcxx_dir -Dxtensor_DIR=$xtensor_dir -DCMAKE_PROGRAM_PATH=$JULIA_HOME -DCMAKE_INSTALL_LIBDIR=lib $xtensor_julia_srcdir`
   `cmake --build . --config $build_type --target install`
 end
 
 xtensor_examples_steps = @build_steps begin
-  `cmake -G "$genopt" -DCMAKE_PREFIX_PATH=$prefix -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE="$build_type" -DJlCxx_DIR=$jlcxx_dir -Dxtensor_DIR=$xtensor_dir -DCMAKE_INSTALL_LIBDIR=lib $xtensor_examples_srcdir`
+  `cmake -G "$genopt" -DCMAKE_PREFIX_PATH=$prefix -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE="$build_type" -DJlCxx_DIR=$jlcxx_dir -Dxtensor_DIR=$xtensor_dir -DCMAKE_PROGRAM_PATH=$JULIA_HOME -DCMAKE_INSTALL_LIBDIR=lib $xtensor_examples_srcdir`
   `cmake --build . --config $build_type --target install`
 end
 

--- a/deps/xtensor-julia/test/FindJulia.cmake
+++ b/deps/xtensor-julia/test/FindJulia.cmake
@@ -32,7 +32,7 @@ MESSAGE(STATUS "Julia_VERSION_STRING: ${Julia_VERSION_STRING}")
 
 if(DEFINED ENV{JULIA_INCLUDE_DIRS})
     set(Julia_INCLUDE_DIRS $ENV{JULIA_INCLUDE_DIRS}
-        CACHE PATH "Location of Julia include files")
+        CACHE STRING "Location of Julia include files")
 else()
     execute_process(
         COMMAND ${Julia_EXECUTABLE} --startup-file=no -E "julia_include_dir = joinpath(match(r\"(.*)(bin)\",JULIA_HOME).captures[1],\"include\",\"julia\")\n
@@ -127,7 +127,7 @@ MESSAGE(STATUS "Julia_LLVM_VERSION:   ${Julia_LLVM_VERSION}")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Julia
-    REQUIRED_VARS   Julia_LIBRARY Julia_LIBRARY_DIR Julia_INCLUDE_DIRS
+    REQUIRED_VARS   Julia_LIBRARY Julia_LIBRARY_DIR Julia_INCLUDE_DIRS Julia_MAIN_HEADER
     VERSION_VAR     Julia_VERSION_STRING
     FAIL_MESSAGE    "Julia not found"
 )


### PR DESCRIPTION
**Dropping Julia 0.5 on Linux**

Support for Julia 0.5 has been dropped, and as of February 22nd 2018, we cannot install packages for Julia 0.5 due to GitHub not supporting old TLS protocol version 1.0 and 1.1, which is builtin with Julia 0.5.

cf https://discourse.julialang.org/t/errors-for-git-pkg/9351 and https://discourse.julialang.org/t/git-ssl-errors-while-installing-packages/9347

**Specifying `DCMAKE_PROGRAM_PATH`**

Julia not being in the path could cause the `find_executable` powering the `findJulia` to fail. It is silly since the cmake was in fact called from Julia itself, so we are specifying the path so that Julia is always found.

**Updating to xtensor 0.15.4**

xtensor 0.15.4 was released with bug fixes and performance improvements.

**Updating findJulia.cmake**

To match exactly the one of CxxWrap which had been modified since we contributed it.