### PR TITLE
Update xtensor to 0.15.9

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda install gtest cmake xtensor==0.15.4 -c conda-forge
+  - conda install gtest cmake xtensor==0.15.9 -c conda-forge
   # Install CxxWrap
   - set BUILD_ON_WINDOWS=1
   - C:\projects\julia-build\bin\julia -E "Pkg.add(\"CxxWrap\")"

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ install:
     - conda update -q conda
     - conda info -a
     # Install xtensor and other conda requirements
-    - conda install xtensor==0.15.4 cmake -c conda-forge
+    - conda install xtensor==0.15.9 cmake -c conda-forge
     - cd deps/xtensor-julia
     # Install CxxWrap
     - julia -E "Pkg.add(\"CxxWrap\")"

--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ cmake -D JlCxx_DIR=/path/to/.julia/v0.5/CxxWrap/deps/usr/share/cmake/JlCxx -D BU
 
 `xtensor-julia` depends on the `xtensor` and `CxxWrap` libraries
 
-| `xtensor-julia` | `xtensor` | `CxxWrap` |
-|-----------------|-----------|-----------|
-| master          |  ^0.15.4  | ^0.6      |
-| 0.1.0           |  ^0.15.4  | ^0.6      |
-| 0.0.11          |  ^0.15.1  | ^0.5      |
-| 0.0.10          |  ^0.14.1  | ^0.5      |
-| 0.0.9           |  ^0.13.1  | ^0.5      |
+| `xtensor-julia` | `xtensor` | `CxxWrap`  |
+|-----------------|-----------|------------|
+| master          |  ^0.15.9  | >=0.5 <0.6 |
+| 0.1.0           |  ^0.15.4  | >=0.5 <0.6 |
+| 0.0.11          |  ^0.15.1  | >=0.5 <0.6 |
+| 0.0.10          |  ^0.14.1  | >=0.5 <0.6 |
+| 0.0.9           |  ^0.13.1  | >=0.5 <0.6 |
 
 These dependencies are automatically resolved when using the Julia package manager.
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
 BinDeps 0.4.2
-CxxWrap 0.5.0
+CxxWrap 0.5.0 0.6.0

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -43,10 +43,10 @@ for l in example_labels
 end
 
 # Version of xtl to vendor
-xtl_version = "0.4.0"
+xtl_version = "0.4.8"
 
 # Version of xtensor-core to vendor
-xtensor_version = "0.15.4"
+xtensor_version = "0.15.9"
 
 xtl_steps = @build_steps begin
   `git clone -b $xtl_version --single-branch https://github.com/QuantStack/xtl $xtl_srcdir`


### PR DESCRIPTION
Dunno what is going on with the windows build.

```
[ 40%] Building CXX object test/CMakeFiles/test_xtensor_julia.dir/test_jlarray.cpp.obj
test_jlarray.cpp
C:\Program Files (x86)\Windows Kits\10\include\10.0.14393.0\um\winnt.h(3122): error C2733: '_mm_prefetch': second C linkage of overloaded function not allowed
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\xmmintrin.h(346): note: see declaration of '_mm_prefetch'
C:\Program Files (x86)\Windows Kits\10\include\10.0.14393.0\um\winnt.h(3128): error C2733: '_m_prefetchw': second C linkage of overloaded function not allowed
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\intrin.h(610): note: see declaration of '_m_prefetchw'
C:\Program Files (x86)\Windows Kits\10\include\10.0.14393.0\um\winscard.h(56): error C2373: 'LPCVOID': redefinition; different type modifiers
C:\Program Files (x86)\Windows Kits\10\include\10.0.14393.0\shared\minwindef.h(174): note: see declaration of 'LPCVOID'
C:\projects\julia-build\include\julia\julia.h(788): warning C4146: unary minus operator applied to unsigned type, result still unsigned
C:\Users\appveyor\.julia\v0.5\CxxWrap\deps\usr\include\jlcxx/type_conversion.hpp(1076): warning C4800: 'int8_t': forcing value to bool 'true' or 'false' (performance warning)
```